### PR TITLE
Clium CLI v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 Changelog
 ---------
 
-**1.2.1+0.9.3**
+**2.0.0+0.9.3**
 
-- update to Cilium CLI `v0.9.3`
+- Set `cilium_cli_version` to `0.9.3`
+- Changed default for `cilium_cli_bin_directory` from `~/.local/bin` to `/usr/local/bin`
+- Introduced `cilium_cli_bin_directory_owner`
+- Introduced `cilium_cli_bin_directory_group`
+- Introduced `cilium_cli_bin_directory_mode`
+- Changed default for `cilium_cli_owner` to `root`
+- Changed default for `cilium_cli_group` to `root`
 
 **1.2.0+0.9.2**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**1.2.1+0.9.3**
+
+- update to Cilium CLI `v0.9.3`
+
 **1.2.0+0.9.2**
 
 - update to Cilium CLI `v0.9.2`

--- a/README.md
+++ b/README.md
@@ -21,19 +21,29 @@ Role Variables
 # "cilium" CLI version to install
 cilium_cli_version: "0.9.3"
 
-# Where to install "cilium" binary. By default that's ".local/bin" in the
-# users $HOME directory.
-cilium_cli_bin_directory: "{{ '~/.local/bin' | expanduser }}"
+# Where to install "cilium" binary. This directory will only be created if
+# "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables
+# are also defined! Otherwise it will be assumend that the destination directory
+# already exits with proper permissions.
+cilium_cli_bin_directory: "/usr/local/bin"
 
-# Directory to store the cilium cli archive
+# If the "cilium" binary should be placed in a directory that doesn't exist yet,
+# this two variables have to be specified to set owner and group of that new
+# directory accordingly.
+# cilium_cli_bin_directory_owner: "root"
+# cilium_cli_bin_directory_group: "root"
+
+# Specifies the permissions of the destination directory.
+cilium_cli_bin_directory_mode: "0755"
+
+# Directory to store the cilium cli archive.
 cilium_cli_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
 
-# Owner/group of "cilium" binary. Both variables are commented by default.
-# In this case the resulting binary will be owned by the current user.
-#cilium_cli_owner: "root"
-#cilium_cli_group: "root"
+# Owner/group of "cilium" binary.
+cilium_cli_owner: "root"
+cilium_cli_group: "root"
 
-# Specifies the permissions of the "cilium" binary
+# Specifies the permissions of the "cilium" binary.
 cilium_cli_binary_mode: "0755"
 
 # Operarting system on which "cilium" should run on.
@@ -44,10 +54,10 @@ cilium_cli_os: "linux"
 # Other possible values: "386","arm64","arm"
 cilium_cli_arch: "amd64"
 
-# Name of the archive file name
+# Name of the archive file name.
 cilium_cli_archive: "cilium-{{ cilium_cli_os }}-{{ cilium_cli_arch }}.tar.gz"
 
-# The cilium CLI download URL (normally no need to change it)
+# The cilium CLI download URL (normally no need to change it).
 cilium_cli_url: "https://github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/{{ cilium_cli_archive }}"
 ```
 
@@ -71,6 +81,25 @@ Example 2 (assign tag to role):
     -
       role: githubixx.cilium_cli
       tags: role-cilium-cli
+```
+
+Testing
+-------
+
+This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-cilium-cli/tree/master/molecule/default).
+
+Afterwards molecule can be executed:
+
+```bash
+molecule converge
+```
+
+This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `cilium_cli` role.
+
+To clean up run
+
+```bash
+molecule destroy
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.9.2"
+cilium_cli_version: "0.9.3"
 
 # Where to install "cilium" binary. By default that's ".local/bin" in the
 # users $HOME directory.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ cilium_cli_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
 
 # Owner/group of "cilium" binary. Both variables are commented by default.
 # In this case the resulting binary will be owned by the current user.
-#cilium_cli_owner: "root"
-#cilium_cli_group: "root"
+# cilium_cli_owner: "root"
+# cilium_cli_group: "root"
 
 # Specifies the permissions of the "cilium" binary
 cilium_cli_binary_mode: "0755"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,19 +2,29 @@
 # "cilium" CLI version to install
 cilium_cli_version: "0.9.3"
 
-# Where to install "cilium" binary. By default that's ".local/bin" in the
-# users $HOME directory.
-cilium_cli_bin_directory: "{{ '~/.local/bin' | expanduser }}"
+# Where to install "cilium" binary. This directory will only be created if
+# "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables
+# are also defined! Otherwise it will be assumend that the destination directory
+# already exits with proper permissions.
+cilium_cli_bin_directory: "/usr/local/bin"
 
-# Directory to store the cilium cli archive
+# If the "cilium" binary should be placed in a directory that doesn't exist yet,
+# this two variables have to be specified to set owner and group of that new
+# directory accordingly.
+# cilium_cli_bin_directory_owner: "root"
+# cilium_cli_bin_directory_group: "root"
+
+# Specifies the permissions of the destination directory.
+cilium_cli_bin_directory_mode: "0755"
+
+# Directory to store the cilium cli archive.
 cilium_cli_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
 
-# Owner/group of "cilium" binary. Both variables are commented by default.
-# In this case the resulting binary will be owned by the current user.
-# cilium_cli_owner: "root"
-# cilium_cli_group: "root"
+# Owner/group of "cilium" binary.
+cilium_cli_owner: "root"
+cilium_cli_group: "root"
 
-# Specifies the permissions of the "cilium" binary
+# Specifies the permissions of the "cilium" binary.
 cilium_cli_binary_mode: "0755"
 
 # Operarting system on which "cilium" should run on.
@@ -25,8 +35,8 @@ cilium_cli_os: "linux"
 # Other possible values: "386","arm64","arm"
 cilium_cli_arch: "amd64"
 
-# Name of the archive file name
+# Name of the archive file name.
 cilium_cli_archive: "cilium-{{ cilium_cli_os }}-{{ cilium_cli_arch }}.tar.gz"
 
-# The cilium CLI download URL (normally no need to change it)
+# The cilium CLI download URL (normally no need to change it).
 cilium_cli_url: "https://github.com/cilium/cilium-cli/releases/download/v{{ cilium_cli_version }}/{{ cilium_cli_archive }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.9.2"
+cilium_cli_version: "0.9.3"
 
 # Where to install "cilium" binary. By default that's ".local/bin" in the
 # users $HOME directory.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,48 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: all
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - block:
+      - name: (Archlinux) Init pacman
+        raw: |
+          pacman-key --init
+          pacman-key --populate archlinux
+        changed_when: false
+        ignore_errors: true
+
+      - name: (Archlinux) Update pacman cache
+        pacman:
+          update_cache: yes
+        changed_when: false
+      when: ansible_distribution|lower == 'archlinux'
+
+    - name: (Ubuntu) Update APT package cache
+      apt:
+        update_cache: "true"
+        cache_valid_time: 3600
+      when: ansible_distribution|lower == 'ubuntu'
+
+- hosts: test-cilium-cli-arch
+  vars_files:
+    - vars/archlinux.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include cilium_cli role
+      include_role:
+        name: githubixx.cilium_cli
+
+- hosts: test-cilium-cli-ubuntu2004
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include cilium_cli role
+      include_role:
+        name: githubixx.cilium_cli

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,49 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+    options:
+      memory: 192
+      cpus: 2
+
+platforms:
+  - name: test-cilium-cli-ubuntu2004
+    box: generic/ubuntu2004
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.10
+  - name: test-cilium-cli-arch
+    box: archlinux/archlinux
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.20
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_become: true
+  log: true
+  lint: yamllint . && flake8 && ansible-lint
+
+scenario:
+  name: default
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible
+  enabled: False

--- a/molecule/default/vars/archlinux.yml
+++ b/molecule/default/vars/archlinux.yml
@@ -1,0 +1,6 @@
+---
+cilium_cli_bin_directory: "/home/vagrant/.local/bin"
+cilium_cli_owner: "vagrant"
+cilium_cli_group: "vagrant"
+cilium_cli_bin_directory_owner: "vagrant"
+cilium_cli_bin_directory_group: "vagrant"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,19 @@
   tags:
     - unarchive
 
+- name: Ensure destination directory
+  file:
+    path: "{{ cilium_cli_bin_directory }}"
+    state: directory
+    mode: "{{ cilium_cli_bin_directory_mode }}"
+    owner: "{{ cilium_cli_bin_directory_owner }}"
+    group: "{{ cilium_cli_bin_directory_group }}"
+  tags:
+    - install
+  when:
+    - cilium_cli_bin_directory_owner is defined
+    - cilium_cli_bin_directory_group is defined
+
 - name: Copy cilium cli binary to destination directory
   copy:
     src: "{{ cilium_cli_tmp_directory }}/{{ item }}"
@@ -27,20 +40,3 @@
     - cilium
   tags:
     - install
-  when:
-    - cilium_cli_owner is defined
-    - cilium_cli_group is defined
-
-- name: Copy cilium cli binary to destination directory
-  copy:
-    src: "{{ cilium_cli_tmp_directory }}/{{ item }}"
-    dest: "{{ cilium_cli_bin_directory }}/{{ item }}"
-    mode: "{{ cilium_cli_binary_mode }}"
-    remote_src: true
-  with_items:
-    - cilium
-  tags:
-    - install
-  when:
-    - cilium_cli_owner is not defined
-    - cilium_cli_group is not defined


### PR DESCRIPTION
- Set `cilium_cli_version` to `0.9.3`
- Changed default for `cilium_cli_bin_directory` from `~/.local/bin` to `/usr/local/bin`
- Introduced `cilium_cli_bin_directory_owner`
- Introduced `cilium_cli_bin_directory_group`
- Introduced `cilium_cli_bin_directory_mode`
- Changed default for `cilium_cli_owner` to `root`
- Changed default for `cilium_cli_group` to `root`