### PR TITLE
2.3.0+0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**2.3.0+0.12.3**
+
+- Set `cilium_cli_version` to `0.12.3`
+
 **2.2.2+0.11.9**
 
 - Set `cilium_cli_version` to `0.11.9`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 **2.3.0+0.12.3**
 
 - Set `cilium_cli_version` to `0.12.3`
+- `tasks/main.yml`: add mode for `get_url` task
+- `tasks/main.yml`: use FQDN Ansible module names
+- `meta/main.yml`: platform versions values should be string
+- `defaults/main.yml`: ansible-lint
+- `meta/main.yml`: `min_ansible_version` value should be string
 
 **2.2.2+0.11.9**
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs [cilium command line](https://github.com/cilium/cilium-cli/) utility.
 Versions
 --------
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `1.1.0+0.9.0` means this is release `1.1.0` of this role and it uses `cilium` CLI version `0.9.0`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `2.3.0+0.12.3` means this is release `2.3.0` of this role and it uses `cilium` CLI version `0.12.3`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
 
 Changelog
 ---------
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.11.9"
+cilium_cli_version: "0.12.3"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.11.9"
+cilium_cli_version: "0.12.3"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ cilium_cli_bin_directory: "/usr/local/bin"
 cilium_cli_bin_directory_mode: "0755"
 
 # Directory to store the cilium cli archive.
-cilium_cli_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp',true) }}"
+cilium_cli_tmp_directory: "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}"
 
 # Owner/group of "cilium" binary.
 cilium_cli_owner: "root"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,22 +10,24 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - bionic
-        - focal
+        - "bionic"
+        - "focal"
+        - "jammy"
     - name: Debian
       versions:
-        - buster
-    - name: Fedora
-      versions:
-        - 33
-        - 34
+        - "buster"
+        - "bullseye"
     - name: EL
       versions:
-        - 7
-        - 8
+        - "7"
+        - "8"
+    - name: Fedora
+      versions:
+        - "34"
+        - "35"
     - name: opensuse
       versions:
-        - 15.2
+        - "15.3"
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,9 @@
+---
 galaxy_info:
   author: Robert Wimmer
   description: Installs cilium command line utility.
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   role_name: cilium_cli
   namespace: githubixx
   platforms:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
     url: "{{ cilium_cli_url }}"
     dest: "{{ cilium_cli_tmp_directory }}/{{ cilium_cli_archive }}"
     checksum: "sha256:{{ cilium_cli_url }}.sha256sum"
+    mode: 0600
   tags:
     - download
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Downloading cilium CLI archive
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ cilium_cli_url }}"
     dest: "{{ cilium_cli_tmp_directory }}/{{ cilium_cli_archive }}"
     checksum: "sha256:{{ cilium_cli_url }}.sha256sum"
@@ -8,7 +8,7 @@
     - download
 
 - name: Unarchive cilium CLI
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ cilium_cli_tmp_directory }}/{{ cilium_cli_archive }}"
     dest: "{{ cilium_cli_tmp_directory }}"
     remote_src: true
@@ -16,7 +16,7 @@
     - unarchive
 
 - name: Ensure destination directory
-  file:
+  ansible.builtin.file:
     path: "{{ cilium_cli_bin_directory }}"
     state: directory
     mode: "{{ cilium_cli_bin_directory_mode }}"
@@ -29,7 +29,7 @@
     - cilium_cli_bin_directory_group is defined
 
 - name: Copy cilium cli binary to destination directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ cilium_cli_tmp_directory }}/{{ item }}"
     dest: "{{ cilium_cli_bin_directory }}/{{ item }}"
     mode: "{{ cilium_cli_binary_mode }}"


### PR DESCRIPTION
- Set `cilium_cli_version` to `0.12.3`
- `tasks/main.yml`: add mode for `get_url` task
- `tasks/main.yml`: use FQDN Ansible module names
- `meta/main.yml`: platform versions values should be string
- `defaults/main.yml`: ansible-lint
- `meta/main.yml`: `min_ansible_version` value should be string
