### PR TITLE
2.4.0+0.12.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'githubixx.cilium_cli'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'githubixx.cilium_cli'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy.
+        run: >-
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 150
+    level: warning
+
+  comments-indentation: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+**2.4.0+0.12.11**
+
+- Set `cilium_cli_version` to `0.12.11`
+- add Github release action to push new release to Ansible Galaxy
+- add `.yamllint`
+- add `verify` for Molecule tests
+
 **2.3.0+0.12.3**
 
 - Set `cilium_cli_version` to `0.12.3`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.12.3"
+cilium_cli_version: "0.12.11"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ molecule converge
 
 This will setup a few virtual machines (VM) with different supported Linux operating systems and installs `cilium_cli` role.
 
+To run a small test if `cilium` command was successfully install run:
+
+```bash
+molecule verify
+```
+
 To clean up run
 
 ```bash

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.12.3"
+cilium_cli_version: "0.12.11"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,25 +7,27 @@
   become: true
   gather_facts: true
   tasks:
-    - block:
-      - name: (Archlinux) Init pacman
-        raw: |
-          pacman-key --init
-          pacman-key --populate archlinux
-        changed_when: false
-        ignore_errors: true
+    - name: Update pacman cache for Archlinux
+      when:
+        - ansible_distribution | lower == 'archlinux'
+      block:
+        - name: (Archlinux) Init pacman
+          raw: |
+            pacman-key --init
+            pacman-key --populate archlinux
+          changed_when: false
+          ignore_errors: true
 
-      - name: (Archlinux) Update pacman cache
-        pacman:
-          update_cache: yes
-        changed_when: false
-      when: ansible_distribution|lower == 'archlinux'
+        - name: (Archlinux) Update pacman cache
+          pacman:
+            update_cache: true
+          changed_when: false
 
     - name: (Ubuntu) Update APT package cache
+      when: ansible_distribution | lower == 'ubuntu'
       apt:
-        update_cache: "true"
+        update_cache: true
         cache_valid_time: 3600
-      when: ansible_distribution|lower == 'ubuntu'
 
 - hosts: test-cilium-cli-arch
   vars_files:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -46,4 +46,4 @@ scenario:
 
 verifier:
   name: ansible
-  enabled: False
+  enabled: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify setup
+  hosts: all
+  vars:
+    expected_output: "v0.12"
+  tasks:
+    - name: Execute cilium version to capture output
+      ansible.builtin.command:
+        cmd: cilium version
+      register: cilium_version_output
+      changed_when: false
+      environment:
+        PATH: "/home/vagrant/.local/bin:{{ ansible_env.PATH }}"
+
+    - name: Ensure cilium version output contains correct version string
+      ansible.builtin.assert:
+        that:
+          - "expected_output in cilium_version_output.stdout"


### PR DESCRIPTION
- Set `cilium_cli_version` to `0.12.11`
- add Github release action to push new release to Ansible Galaxy
- add `.yamllint`
- add `verify` for Molecule tests