### PR TITLE
2.6.0+0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,26 @@
 Changelog
 ---------
 
+**2.6.0+0.13.2**
+
+- set `cilium_cli_version` to `0.13.2`
+- add molecule/default/prepare.yml and move tasks from molecule/default/converge.yml
+
 **2.5.0+0.13.1**
 
-- Set `cilium_cli_version` to `0.13.1`
+- set `cilium_cli_version` to `0.13.1`
 - fix Molecule `converge.yml`
 
 **2.4.0+0.12.11**
 
-- Set `cilium_cli_version` to `0.12.11`
+- set `cilium_cli_version` to `0.12.11`
 - add Github release action to push new release to Ansible Galaxy
 - add `.yamllint`
 - add `verify` for Molecule tests
 
 **2.3.0+0.12.3**
 
-- Set `cilium_cli_version` to `0.12.3`
+- set `cilium_cli_version` to `0.12.3`
 - `tasks/main.yml`: add mode for `get_url` task
 - `tasks/main.yml`: use FQDN Ansible module names
 - `meta/main.yml`: platform versions values should be string
@@ -24,29 +29,29 @@ Changelog
 
 **2.2.2+0.11.9**
 
-- Set `cilium_cli_version` to `0.11.9`
+- set `cilium_cli_version` to `0.11.9`
 
 **2.2.1+0.11.7**
 
-- Set `cilium_cli_version` to `0.11.7`
+- set `cilium_cli_version` to `0.11.7`
 
 **2.2.0+0.11.4**
 
-- Set `cilium_cli_version` to `0.11.4`
+- set `cilium_cli_version` to `0.11.4`
 
 **2.1.0+0.10.3**
 
-- Set `cilium_cli_version` to `0.10.3`
+- set `cilium_cli_version` to `0.10.3`
 
 **2.0.0+0.9.3**
 
-- Set `cilium_cli_version` to `0.9.3`
-- Changed default for `cilium_cli_bin_directory` from `~/.local/bin` to `/usr/local/bin`
-- Introduced `cilium_cli_bin_directory_owner`
-- Introduced `cilium_cli_bin_directory_group`
-- Introduced `cilium_cli_bin_directory_mode`
-- Changed default for `cilium_cli_owner` to `root`
-- Changed default for `cilium_cli_group` to `root`
+- set `cilium_cli_version` to `0.9.3`
+- changed default for `cilium_cli_bin_directory` from `~/.local/bin` to `/usr/local/bin`
+- introduced `cilium_cli_bin_directory_owner`
+- introduced `cilium_cli_bin_directory_group`
+- introduced `cilium_cli_bin_directory_mode`
+- changed default for `cilium_cli_owner` to `root`
+- changed default for `cilium_cli_group` to `root`
 
 **1.2.0+0.9.2**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 **2.6.0+0.13.2**
 
 - set `cilium_cli_version` to `0.13.2`
-- add molecule/default/prepare.yml and move tasks from molecule/default/converge.yml
+- add `molecule/default/prepare.yml` and move tasks from `molecule/default/converge.yml`
 
 **2.5.0+0.13.1**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.13.1"
+cilium_cli_version: "0.13.2"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.13.1"
+cilium_cli_version: "0.13.2"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,35 +1,6 @@
 ---
-# Copyright (C) 2021 Robert Wimmer
+# Copyright (C) 2023 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-- hosts: test-cilium-cli-arch
-  remote_user: vagrant
-  become: true
-  gather_facts: false
-  tasks:
-    - name: Init pacman
-      ansible.builtin.raw: |
-        pacman-key --init
-        pacman-key --populate archlinux
-      changed_when: false
-      failed_when: false
-
-    - name: Install Python
-      ansible.builtin.raw: |
-        pacman -S --noconfirm python
-      args:
-        executable: /bin/bash
-      changed_when: false
-
-- hosts: test-cilium-cli-ubuntu2004
-  remote_user: vagrant
-  become: true
-  gather_facts: true
-  tasks:
-    - name: Update APT package cache
-      apt:
-        update_cache: true
-        cache_valid_time: 3600
 
 - hosts: test-cilium-cli-arch
   vars_files:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,35 @@
+---
+# Copyright (C) 2023 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: test-cilium-cli-arch
+  remote_user: vagrant
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Init pacman
+      ansible.builtin.raw: |
+        pacman-key --init
+        pacman-key --populate archlinux
+      changed_when: false
+      failed_when: false
+
+    - name: Updating pacman cache
+      raw: pacman -Sy
+
+    - name: Install Python
+      ansible.builtin.raw: |
+        pacman -S --noconfirm python
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+- hosts: test-cilium-cli-ubuntu2004
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600


### PR DESCRIPTION
- set `cilium_cli_version` to `0.13.2`
- add `molecule/default/prepare.yml` and move tasks from `molecule/default/converge.yml`