### PR TITLE
0.15.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**2.7.0+0.15.8**
+
+- set `cilium_cli_version` to `0.15.8`
+
 **2.7.0+0.14.6**
 
 - set `cilium_cli_version` to `0.14.6`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **2.7.0+0.15.8**
 
 - set `cilium_cli_version` to `0.15.8`
+- add Molecule test for Ubuntu 22.04
+- `molecule/default/molecule.yml`: move `memory` and `cpus` options to instances
 
 **2.7.0+0.14.6**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Role Variables
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.14.6"
+cilium_cli_version: "0.15.8"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.14.6"
+cilium_cli_version: "0.15.8"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,7 +13,7 @@
       include_role:
         name: githubixx.cilium_cli
 
-- hosts: test-cilium-cli-ubuntu2004
+- hosts: test-cilium-cli-ubuntu2004, test-cilium-cli-ubuntu2204
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,13 +10,12 @@ driver:
   provider:
     name: libvirt
     type: libvirt
-    options:
-      memory: 192
-      cpus: 2
 
 platforms:
   - name: test-cilium-cli-ubuntu2004
     box: generic/ubuntu2004
+    memory: 2048
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -24,6 +23,8 @@ platforms:
         ip: 192.168.10.10
   - name: test-cilium-cli-arch
     box: archlinux/archlinux
+    memory: 2048
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network
@@ -31,6 +32,8 @@ platforms:
         ip: 192.168.10.20
   - name: test-cilium-cli-ubuntu2204
     box: generic/ubuntu2204
+    memory: 2048
+    cpus: 2
     interfaces:
       - auto_config: true
         network_name: private_network

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -29,6 +29,13 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.20
+  - name: test-cilium-cli-ubuntu2204
+    box: generic/ubuntu2204
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.30
 
 provisioner:
   name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v0.14"
+    expected_output: "v0.15"
   tasks:
     - name: Execute cilium version to capture output
       ansible.builtin.command:

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - cilium-cli


### PR DESCRIPTION
- set `cilium_cli_version` to `0.15.8`
- add Molecule test for Ubuntu 22.04
- `molecule/default/molecule.yml`: move `memory` and `cpus` options to instances