### PR TITLE
3.0.0+0.18.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Copyright (C) 2025 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+molecule/kvm/.vagrant
+.vscode
+.ansible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.0.0+0.18.5
+
+- set `cilium_cli_version` to `0.18.5`
+- Molecule: Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
+- Molecule: add Ubuntu 24.04 / add host groups / install `openssl` and `archlinux-keyring` packages for Archlinux
+- Molecule: `verify.yml` change expected_output value
+- Removed Ubuntu 20.04 because reached end of life
+- add `.gitignore`
+- update `meta/main.yml`
+
 ## 2.8.2+0.16.23
 
 - set `cilium_cli_version` to `0.16.23`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Installs [cilium command line](https://github.com/cilium/cilium-cli/) utility.
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `2.8.1+0.16.19` means this is release `2.8.1` of this role and it uses `cilium` CLI version `0.16.19`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `3.0.0+0.18.5` means this is release `3.0.0` of this role and it uses `cilium` CLI version `0.18.5`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
 
 ## Changelog
 
@@ -15,7 +15,7 @@ see [CHANGELOG.md](https://github.com/githubixx/ansible-role-cilium-cli/blob/mas
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.16.23"
+cilium_cli_version: "0.18.5"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.16.23"
+cilium_cli_version: "0.18.5"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,7 +26,7 @@ galaxy_info:
         - "42"
     - name: opensuse
       versions:
-        - "15.6"
+        - "15.5"
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,24 +10,23 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "bionic"
         - "focal"
         - "jammy"
     - name: Debian
       versions:
-        - "buster"
         - "bullseye"
+        - "bookworm"
     - name: EL
       versions:
         - "7"
         - "8"
     - name: Fedora
       versions:
-        - "34"
-        - "35"
+        - "41"
+        - "42"
     - name: opensuse
       versions:
-        - "15.3"
+        - "15.6"
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2023 Robert Wimmer
+# Copyright (C) 2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts
-  hosts: test-cilium-cli-arch
+  hosts: archlinux
   vars_files:
     - vars/archlinux.yml
   remote_user: vagrant
@@ -15,7 +15,7 @@
         name: githubixx.cilium_cli
 
 - name: Setup Ubuntu hosts
-  hosts: test-cilium-cli-ubuntu2004, test-cilium-cli-ubuntu2204
+  hosts: ubuntu
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-cilium-cli-arch
-    box: archlinux/archlinux
+    box: generic/arch
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,7 +24,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-cilium-cli-ubuntu2204
-    box: alvistack/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -34,7 +34,7 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.30
-  - name: test-docker-ubuntu2404
+  - name: test-cilium-cli-ubuntu2404
     box: alvistack/ubuntu-24.04
     memory: 2048
     cpus: 2

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021 Robert Wimmer
+# Copyright (C) 2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:
@@ -12,15 +12,6 @@ driver:
     type: libvirt
 
 platforms:
-  - name: test-cilium-cli-ubuntu2004
-    box: generic/ubuntu2004
-    memory: 2048
-    cpus: 2
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 172.16.10.10
   - name: test-cilium-cli-arch
     box: archlinux/archlinux
     memory: 2048

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,20 +16,35 @@ platforms:
     box: archlinux/archlinux
     memory: 2048
     cpus: 2
+    groups:
+      - archlinux
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 172.16.10.20
   - name: test-cilium-cli-ubuntu2204
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu2204
     memory: 2048
     cpus: 2
+    groups:
+      - ubuntu
     interfaces:
       - auto_config: true
         network_name: private_network
         type: static
         ip: 172.16.10.30
+  - name: test-docker-ubuntu2404
+    box: alvistack/ubuntu-24.04
+    memory: 2048
+    cpus: 2
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.40
 
 provisioner:
   name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2023 Robert Wimmer
+# Copyright (C) 2025 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts
@@ -30,7 +30,7 @@
       changed_when: false
 
 - name: Setup Ubuntu hosts
-  hosts: test-cilium-cli-ubuntu2004, test-cilium-cli-ubuntu2204
+  hosts: test-cilium-cli-ubuntu2204
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts
-  hosts: test-cilium-cli-arch
+  hosts: archlinux
   remote_user: vagrant
   become: true
   gather_facts: false
@@ -18,19 +18,17 @@
     - name: Updating pacman cache
       ansible.builtin.raw: |
         pacman -Sy
-      args:
-        executable: /bin/bash
       changed_when: false
 
-    - name: Install Python
+    - name: Install support packages
       ansible.builtin.raw: |
-        pacman -S --noconfirm python
+        pacman -S --noconfirm python openssl archlinux-keyring
       args:
         executable: /bin/bash
       changed_when: false
 
 - name: Setup Ubuntu hosts
-  hosts: test-cilium-cli-ubuntu2204
+  hosts: ubuntu
   remote_user: vagrant
   become: true
   gather_facts: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v0.16"
+    expected_output: "v0.18"
   tasks:
     - name: Execute cilium version to capture output
       ansible.builtin.command:


### PR DESCRIPTION
- set `cilium_cli_version` to `0.18.5`
- Molecule: Use `generic/arch` Vagrant box instead of `archlinux/archlinux` (no longer available)
- Molecule: add Ubuntu 24.04 / add host groups / install `openssl` and `archlinux-keyring` packages for Archlinux
- Molecule: `verify.yml` change expected_output value
- Removed Ubuntu 20.04 because reached end of life
- add `.gitignore`
- update `meta/main.yml`