### PR TITLE
3.1.0+0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.0+0.19.2
+
+- set `cilium_cli_version` to `0.19.2`
+- update `meta/main.yml`
+- Molecule: use own `githubixx` Vagrant boxes
+- Molecule: `verify.yml` change `expected_output` value / replace injected `ansible_*` facts usage
+- Molecule: update years
+- Molecule: add test for Ubuntu 26.04
+
 ## 3.0.0+0.18.5
 
 - set `cilium_cli_version` to `0.18.5`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Installs [cilium command line](https://github.com/cilium/cilium-cli/) utility.
 
 ## Versions
 
-I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `3.0.0+0.18.5` means this is release `3.0.0` of this role and it uses `cilium` CLI version `0.18.5`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
+I tag every release and try to stay with [semantic versioning](http://semver.org). If you want to use the role I recommend to checkout the latest tag. The master branch is basically development while the tags mark stable releases. But in general I try to keep master in good shape too. A tag `3.1.0+0.19.2` means this is release `3.1.0` of this role and it uses `cilium` CLI version `0.19.2`. If the role itself changes `X.Y.Z` before `+` will increase. If the `cilium` CLI version changes `X.Y.Z` after `+` will increase too. This allows to tag bugfixes and new major versions of the role while it's still developed for a specific `cilium` CLI release.
 
 ## Changelog
 
@@ -15,7 +15,7 @@ see [CHANGELOG.md](https://github.com/githubixx/ansible-role-cilium-cli/blob/mas
 ```yaml
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.18.5"
+cilium_cli_version: "0.19.2"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # "cilium" CLI version to install
-cilium_cli_version: "0.18.5"
+cilium_cli_version: "0.19.2"
 
 # Where to install "cilium" binary. This directory will only be created if
 # "cilium_cli_bin_directory_owner" and "cilium_cli_bin_directory_group variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,23 +10,23 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "focal"
         - "jammy"
+        - "noble"
     - name: Debian
       versions:
         - "bullseye"
         - "bookworm"
+        - "trixie"
     - name: EL
       versions:
-        - "7"
-        - "8"
+        - "9"
+        - "10"
     - name: Fedora
       versions:
-        - "41"
-        - "42"
+        - "all"
     - name: opensuse
       versions:
-        - "15.5"
+        - "all"
   galaxy_tags:
     - kubernetes
     - kubectl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
       versions:
         - "jammy"
         - "noble"
+        - "resolute"
     - name: Debian
       versions:
         - "bullseye"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -45,6 +45,17 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.40
+  - name: test-cilium-cli-ubuntu2604
+    box: githubixx/ubuntu-26.04
+    memory: 2048
+    cpus: 2
+    groups:
+      - ubuntu
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.50
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ driver:
 
 platforms:
   - name: test-cilium-cli-arch
-    box: generic/arch
+    box: githubixx/archlinux
     memory: 2048
     cpus: 2
     groups:
@@ -24,7 +24,7 @@ platforms:
         type: static
         ip: 172.16.10.20
   - name: test-cilium-cli-ubuntu2204
-    box: alvistack/ubuntu-22.04
+    box: githubixx/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -35,7 +35,7 @@ platforms:
         type: static
         ip: 172.16.10.30
   - name: test-cilium-cli-ubuntu2404
-    box: alvistack/ubuntu-24.04
+    box: githubixx/ubuntu-24.04
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2025 Robert Wimmer
+# Copyright (C) 2021-2026 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Setup Archlinux hosts

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: Verify setup
   hosts: all
   vars:
-    expected_output: "v0.18"
+    expected_output: "v0.19"
   tasks:
     - name: Execute cilium version to capture output
       ansible.builtin.command:
@@ -10,7 +10,7 @@
       register: cilium_version_output
       changed_when: false
       environment:
-        PATH: "/home/vagrant/.local/bin:{{ ansible_env.PATH }}"
+        PATH: "/home/vagrant/.local/bin:{{ ansible_facts['env']['PATH'] }}"
 
     - name: Ensure cilium version output contains correct version string
       ansible.builtin.assert:


### PR DESCRIPTION
- set `cilium_cli_version` to `0.19.2`
- update `meta/main.yml`
- Molecule: use own `githubixx` Vagrant boxes
- Molecule: `verify.yml` change `expected_output` value / replace injected `ansible_*` facts usage
- Molecule: update years
- Molecule: add test for Ubuntu 26.04